### PR TITLE
fix package name

### DIFF
--- a/webhook-collector/package-lock.json
+++ b/webhook-collector/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "webhook-collector-opensearch",
+  "name": "webhook-collector",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webhook-collector-opensearch",
+      "name": "webhook-collector",
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {

--- a/webhook-collector/package.json
+++ b/webhook-collector/package.json
@@ -8,8 +8,8 @@
     "build": "./build.sh",
     "test": "eslint ; mocha __test__/**/*.test.js"
   },
-  "name": "webhook-collector-opensearch",
-  "description": "A simple webhook collector for OpenSearch",
+  "name": "webhook-collector",
+  "description": "A simple webhook collector for GitHub webhook events",
   "version": "0.1.0",
   "license": "ISC",
   "engines": {


### PR DESCRIPTION
The most important changes are:

* [`webhook-collector/package-lock.json`](diffhunk://#diff-77d517a1b12b22d19cba3d97bc30fd4fb55ee83794465b3ab4cb542637e5287bL2-R8): The package name was changed from `webhook-collector-opensearch` to `webhook-collector`.
* [`webhook-collector/package.json`](diffhunk://#diff-9481c47a91dab013813175894104e1eafac821a8e088973b79526ec93ddc91c1L11-R12): The package name was changed from `webhook-collector-opensearch` to `webhook-collector`, and the description was updated to "A simple webhook collector for GitHub webhook events".