### PR TITLE
Update Node.js version from 20 to 24

### DIFF
--- a/.github/workflows/ci-webhook-collector.yml
+++ b/.github/workflows/ci-webhook-collector.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install Dependencies
         run: |
           cd webhook-collector


### PR DESCRIPTION
This pull request updates the Node.js version used in the CI workflow for the webhook collector. The change ensures the project uses the latest LTS version during continuous integration.